### PR TITLE
Extend crate metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Daniel Danis", "Daniel Danis <daniel.gordon.danis@protonmail.com>"]
 edition = "2021"
 description = "Rust bindings for Phenopacket Schema"
 readme = "README.md"
+homepage = "https://github.com/ielis/phenopackets-dev"
+repository = "https://github.com/ielis/phenopackets-dev"
 license-file = "LICENSE"
 keywords = ["phenopackets", "phenotype", "ontology", "bioinformatics"]
 


### PR DESCRIPTION
Add homepage and repository to `Cargo.toml`.